### PR TITLE
Adding uart and initial coding of command prompt

### DIFF
--- a/.launches/twine_FR4133.launch
+++ b/.launches/twine_FR4133.launch
@@ -4,7 +4,7 @@
         <mapEntry key="org.eclipse.cdt.debug.ui.memory.memorybrowser.MemoryBrowser@#$TI MSP430 USB1/MSP430@#$0" value="16-Bit Hex - TI Style"/>
     </mapAttribute>
     <mapAttribute key="ccs.memoryview.pageexpr">
-        <mapEntry key="org.eclipse.cdt.debug.ui.memory.memorybrowser.MemoryBrowser@#$TI MSP430 USB1/MSP430" value="@@0x3"/>
+        <mapEntry key="org.eclipse.cdt.debug.ui.memory.memorybrowser.MemoryBrowser@#$TI MSP430 USB1/MSP430" value="PROGRAM@@0x3cc"/>
     </mapAttribute>
     <stringAttribute key="com.ti.ccstudio.debug.debugModel.ATTR_DEBUGGER_PROPERTIES.MSP430FR4133.ccxml.TI MSP430 USB1/MSP430" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot; ?&gt;&#10;&lt;PropertyValues&gt;&#10;&#10;  &lt;property id=&quot;ConnectOnStartup&quot;&gt;&#10;    &lt;curValue&gt;1&lt;/curValue&gt;&#10;  &lt;/property&gt;&#10;&#10;  &lt;property id=&quot;EnableInstalledBreakpoint&quot;&gt;&#10;    &lt;curValue&gt;1&lt;/curValue&gt;&#10;  &lt;/property&gt;&#10;&#10;&lt;/PropertyValues&gt;&#10;"/>
     <setAttribute key="com.ti.ccstudio.debug.debugModel.ATTR_HIDE_CONFIG_ELEMENT_TYPES">

--- a/clocks.c
+++ b/clocks.c
@@ -10,17 +10,47 @@
 
 #include "twine.h"
 
+// FLL:    Frequency Locked Loop
+// DCO:    Digitally Controlled Oscillator
+// VLO:    Very Low-Power Low-Frequency Oscillator (10Khz typical)
+//         possible sources for MCLK and SMCLK
+// REFO:   Internal Trimmed Low-Frequency Reference Oscillator (32.768 khz typical)
+//         can be used as FLLREFCLK, so no need for external crystal
+// XT1:    external 32.768 khz crystal, external high-frequency optional
+//         can be run in low-frequency (LF) or high-frequency modes (HF)
+//         possible sources for MCLK, SMCLK, ACLK and FLLREGCLK
+// MODOSC: Module Oscillator (5 mhz typical)
+//         internal oscillator
+//         sources MODCLK
+
+// ACLK:   Auxiliary clock
+//         low-frequency peripherals, typical 32.768 khz (max 40 khz)
+// MCLK:   Master clock
+//         CPU clock
+//         can be sourced from REFO, DCO, XT1 or VLO
+// SMCLK:  Subsystem Master clock
+//         used by peripherals, always sourced from MCLK
+//
+// BRCLK:  Baud Rate clock
+//         possible sources UCLK and SMCLK
+// UCLK:   optional source to eUSCI (uart, i2c, spi), externally provided
+//         not much in docs, likely part specific
+
 /*****************************************************************************/
 void startXt1Clk(void)
 {
+    CSCTL0 = 0x0000;
+
     // select XIN and XOUT as functional pins on P4.1 and P4.2
     P4SEL0 |= (BIT1 | BIT2);
 
     while(CSCTL7 & XT1OFFG)
     {
         CSCTL7 &= (unsigned char) ~XT1OFFG;
-        SFRIFG1 &= (unsigned char) ~OFIFG;
+        CSCTL7 &= (unsigned char) ~DCOFFG;
     }
+
+    while (CSCTL7 & (FLLUNLOCK0 | FLLUNLOCK0)); // Poll until FLL is locked
 }
 
 /*****************************************************************************/

--- a/clocks.h
+++ b/clocks.h
@@ -12,4 +12,6 @@
 void startXt1Clk(void);
 void startRtcClk(void);
 
+#define RTC_MOD_COUNT 128
+
 #endif

--- a/gpios.c
+++ b/gpios.c
@@ -10,17 +10,21 @@
 
 #include "twine.h"
 
-void initGpios(void)
+void gpiosInit(void)
 {
     PASEL0 = 0x0000;
     PADIR  = 0xFFFF;
     PAOUT  = 0x0000;
+    PAIFG  = 0x0000;
+
     PBSEL0 = 0x0000;
     PBDIR  = 0xFFFF;
     PBOUT  = 0x0000;
+
     PCSEL0 = 0x0000;
     PCDIR  = 0xFFFF;
     PCOUT  = 0x0000;
+
     PDSEL0 = 0x000;
     PDDIR  = 0xFFF;
     PDOUT  = 0x000;

--- a/gpios.h
+++ b/gpios.h
@@ -9,6 +9,6 @@
 #ifndef GPIOS_H
 #define GPIOS_H
 
-void initGpios(void);
+void gpiosInit(void);
 
 #endif

--- a/interrupts.c
+++ b/interrupts.c
@@ -11,7 +11,7 @@
 #include "twine.h"
 
 /*****************************************************************************/
-/* Externs - these global variables are declared in tasks.c                  */
+/* externs - these global variables are declared in tasks.c                  */
 /*****************************************************************************/
 extern unsigned short task_1_status;
 extern unsigned short task_2_status;
@@ -23,10 +23,15 @@ extern short task_3_timeout;
 extern short task_4_timeout;
 
 /*****************************************************************************/
-/* Reference to the vector pragma can be found in slau132y.pdf v21.6.0.LTS   */
+/* global declarations                                                       */
+/*****************************************************************************/
+unsigned char uartRxBuf[UART_RX_BUF_SIZE];
+unsigned char uartTxBuf[UART_TX_BUF_ARRAY_SIZE][UART_TX_BUF_SIZE];
+
+/*****************************************************************************/
+/* Reference to the vector pragmas can be found in slau132y.pdf v21.6.0.LTS   */
 /*****************************************************************************/
 #pragma vector = RTC_VECTOR
-
 /*****************************************************************************/
 /* RTC interrupt, initialization is done in clocks.c                         */
 /**********************************************************AJP****************/
@@ -49,4 +54,77 @@ __interrupt void RTCIntervalInterrupt(void)
 
     if(task_4_status)
         task_4_timeout--;
+}
+
+/*****************************************************************************/
+#pragma vector = USCI_A0_VECTOR
+/*****************************************************************************/
+__interrupt void USCIA0Interrupt(void)
+{
+
+    volatile unsigned char rxReg;
+    static unsigned int i, j, k;
+
+    switch(__even_in_range(UCA0IV, 18))
+    {
+        case 0x00: // No interrupts
+        break;
+
+        case 0x02: // RX interrupt
+            rxReg = read_reg_8(EUSCI_A0_BASE + 0xC);
+            if(i < UART_RX_BUF_SIZE - 1)
+            {
+                uartRxBuf[i++] = rxReg;
+
+                if(rxReg == 0x0D)
+                    i = 0;
+            }
+            else
+            {
+                uartRxBuf[i] = rxReg;
+                i = 0;
+            }
+
+            if(!(UCA0IFG & UCTXIE))
+                UCA0IFG |= UCTXIE;
+        break;
+
+        case 0x04: // TX interrupt
+
+            if((rxReg >= 0x20) && (rxReg < 0x7f))
+            {
+                UCA0TXBUF = rxReg;
+                rxReg = 0;
+            }
+
+loop:
+            if(k < 4)
+            {
+                if(uartTxBuf[k][j])
+                {
+                    UCA0TXBUF = uartTxBuf[k][j++];
+                    uartTxBuf[k][j-1] = 0x00;
+                }
+                else
+                {
+                    j = 0;
+                    k++;
+                    goto loop;
+                }
+            }
+            else
+                k = 0;
+        break;
+
+        case 0x06: // Start bit interrupt
+            UCA0IFG &= ~UCSTTIFG;
+        break;
+
+        case 0x08: // TX complete interrupt
+            UCA0IFG &= ~UCTXCPTIFG;
+        break;
+
+        default:
+        break;
+    }
 }

--- a/main.c
+++ b/main.c
@@ -10,15 +10,40 @@
 
 #include "twine.h"
 
-int main( void )
-{
-    WDTCTL = WDTPW + WDTHOLD;       // [stop] disable watchdog timer
+/*****************************************************************************/
+/* extern declarations                                                       */
+/*****************************************************************************/
+extern unsigned char uartTxBuf[UART_TX_BUF_ARRAY_SIZE][UART_TX_BUF_SIZE];
 
-    initGpios();
+/*****************************************************************************/
+/* static (local) declarations                                               */
+/*****************************************************************************/
+static unsigned char banner[]  = "\r\ntwine\r\n# ";
+
+/*****************************************************************************/
+int main(void)
+{
+    WDTCTL = WDTPW + WDTHOLD;       // disable watchdog timer
+
+    gpiosInit();
+    powerInit();
     startXt1Clk();
     startRtcClk();
+    uartInit();
+
+    // If this is a power up then wait for USB enumeration.
+    // Allows use with "backchannel" UART-over-USB at power-up.
+    RTCMOD = 0xF00;
+    RTCCTL |= RTCSR;
+    if(SYSRSTIV == 0x0002) // test for BOR
+    {
+        while(read_reg_16(RTC_BASE + 0x0C) < RTC_MOD_COUNT);
+    }
+    RTCMOD = RTC_MOD_COUNT;
 
     __enable_interrupt();
+
+    uartTx(uartTxBuf, 0, banner);
 
     taskManager();
 

--- a/power.c
+++ b/power.c
@@ -1,0 +1,6 @@
+#include "twine.h"
+
+void powerInit(void)
+{
+    PM5CTL0 &= ~LOCKLPM5;
+}

--- a/power.h
+++ b/power.h
@@ -1,0 +1,6 @@
+#ifndef POWER_H
+#define POWER_H
+
+void powerInit(void);
+
+#endif

--- a/tasks.c
+++ b/tasks.c
@@ -11,7 +11,13 @@
 #include "twine.h"
 
 /*****************************************************************************/
-/* Global declarations                                                       */
+/* extern declarations                                                       */
+/*****************************************************************************/
+extern unsigned char uartRxBuf[UART_RX_BUF_SIZE];
+extern unsigned char uartTxBuf[UART_TX_BUF_ARRAY_SIZE][UART_TX_BUF_SIZE];
+
+/*****************************************************************************/
+/* global declarations                                                       */
 /*****************************************************************************/
 unsigned short task_1_status = 0;
 unsigned short task_2_status = 0;
@@ -24,7 +30,7 @@ short task_3_timeout = 0;
 short task_4_timeout = 0;
 
 /*****************************************************************************/
-/* Static (local) declarations                                               */
+/* static (local) declarations                                               */
 /*****************************************************************************/
 static unsigned short *SP_current;
 static unsigned short task_current = 0;
@@ -43,6 +49,10 @@ static unsigned short task_1_stack[8];
 static unsigned short task_2_stack[8];
 static unsigned short task_3_stack[8];
 static unsigned short task_4_stack[8];
+
+static unsigned char prompt[]  = "\r\n# ";
+static unsigned char help[]    = "\r\nh: help\r\nv: version";
+static unsigned char version[] = "\r\nv:1.1";
 
 /*****************************************************************************/
 void taskManager(void)
@@ -262,11 +272,30 @@ void taskTimeoutLock(short num, short count)
 /*****************************************************************************/
 short task_1(void)
 {
+    unsigned short i = 0;
+    unsigned short j = 0;
+
     task_1_stack_size = ((taskManager_stack_1 - (unsigned short) __get_SP_register())>>1) + 1;
-    P1OUT |= BIT0; // turn on LED1
-    taskSleep(1);
-    P1OUT &= ~BIT0; // turn off LED 1
-    taskSleep(1);
+
+    while(uartRxBuf[j])
+    {
+        if(uartRxBuf[j++] == 0x0d)
+        {
+            for(i=0;i<j;i++)
+            {
+                if(uartRxBuf[i] == 'h')
+                    uartTx(uartTxBuf, 0, help);
+                else if(uartRxBuf[i] == 'v')
+                    uartTx(uartTxBuf, 0, version);
+            }
+
+            uartTx(uartTxBuf, 0, prompt);
+
+            for(i=0;i<UART_RX_BUF_SIZE;i++)
+                uartRxBuf[i] = 0x00;
+        }
+    };
+
     return 0;
 }
 
@@ -274,21 +303,19 @@ short task_1(void)
 short task_2(void)
 {
     task_2_stack_size = ((taskManager_stack_2 - (unsigned short) __get_SP_register())>>1) + 1;
-    P4OUT |= BIT0; // turn on LED2
-    taskSleep(4);
-    P4OUT &= ~BIT0; // turn off LED 2
-    taskSleep(1);
     return 0;
 }
 
 /*****************************************************************************/
 short task_3(void)
 {
+    task_3_stack_size = ((taskManager_stack_3 - (unsigned short) __get_SP_register())>>1) + 1;
     return 0;
 }
 
 /*****************************************************************************/
 short task_4(void)
 {
+    task_4_stack_size = ((taskManager_stack_4 - (unsigned short) __get_SP_register())>>1) + 1;
     return 0;
 }

--- a/twine.h
+++ b/twine.h
@@ -14,10 +14,14 @@
 #define TWINE_H
 
 #include <msp430.h>
+
 #include "clocks.h"
 #include "gpios.h"
 #include "tasks.h"
+#include "uart.h"
+#include "power.h"
 
-#define RTC_MOD_COUNT 128
+#define read_reg_8(x) (*((volatile unsigned char *)((unsigned short)x)))
+#define read_reg_16(x) (*((volatile unsigned short *)((unsigned short)x)))
 
 #endif

--- a/uart.c
+++ b/uart.c
@@ -1,0 +1,49 @@
+#include "twine.h"
+
+void uartInit(void)
+{
+    P1SEL0 |= BIT0;
+    P1SEL0 |= BIT1;
+
+    UCA0CTLW0 |= UCSWRST;
+    UCA0CTLW0 |= UCSSEL_3;
+
+// 9600 baud @ 2Mhz SMCLK
+#ifdef BAUD_RATE_9600
+    UCA0MCTLW = 0x2000;   // UCBRSx
+    UCA0MCTLW |= BIT0;    // UCOS16
+    UCA0BRW = 0x0006;     // UCBRx
+    UCA0MCTLW |= UCBRF_8; // UCBRFx
+#endif
+
+// 115200 baud @ 2Mhz SMCLK
+#ifdef BAUD_RATE_115200
+    UCA0MCTLW = 0xD600;   // UCBRSx
+    UCA0MCTLW &= ~BIT0;   // UCOS16
+    UCA0BRW = 0x0008;     // UCBRx
+    UCA0MCTLW |= UCBRF_0; // UCBRFx
+#endif
+
+    UCA0CTLW0 &= ~UCSWRST;
+
+    UCA0IE |= UCRXIE;
+}
+
+/*****************************************************************************/
+short uartTx(unsigned char (*txStr)[UART_RX_BUF_SIZE], unsigned int node, unsigned char *str)
+{
+
+    unsigned int i = 0;
+    unsigned int j = 0;
+
+    UCA0IE &= ~UCTXIE;
+    do
+        txStr[node][i++] = str[j];
+    while(str[j++]);
+    if(!(UCA0IFG & UCTXIE))
+        UCA0IFG |= UCTXIE;
+    UCA0IE |= UCTXIE;
+
+    return j;
+}
+

--- a/uart.h
+++ b/uart.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * uart.h
+ *
+ * Copyright (C) 2022 Alex Pogostin <alex.pogostin@outlook.com>
+ *
+ */
+
+#ifndef UART_H
+#define UART_H
+
+#define BAUD_RATE_115200
+
+#define UART_RX_BUF_SIZE 32
+#define UART_TX_BUF_ARRAY_SIZE 4
+#define UART_TX_BUF_SIZE 32
+
+void uartInit(void);
+short uartTx(unsigned char (*txStr)[UART_RX_BUF_SIZE], unsigned int node, unsigned char *str);
+
+#endif


### PR DESCRIPTION
Several changes, including adding UART for use in command line prompt management and entry. Adding two simple commands, 'h' and 'v' as place holders/examples. Also added some code in main(...) to handle issues regarding using the backchannel uart interface and waiting on USB enumeration to complete.