### PR TITLE
moving-task4-code-to-interpreter-c

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -14,7 +14,7 @@
 /* global declarations                                                       */
 /*****************************************************************************/
 unsigned char token_tree[MAX_TOKEN_TREE_SIZE];
-int token_pointer;
+int tokenPointer;
 
 /*****************************************************************************/
 /* static (local) declarations                                               */
@@ -57,10 +57,13 @@ int lexer(unsigned char *program)
             break;
     }
 
-    do
+    while(token[tokenNum])
     {
+
+        // if line contains yes:, but token=pressed
         if(*(token[tokenNum]) > progLineLen)
         {
+            tokenNum++;
             continue;
         }
 
@@ -85,11 +88,13 @@ int lexer(unsigned char *program)
         if(matchLen < *(token[tokenNum]) || matchLen > *(token[tokenNum]))
         {
             matchLen = 0;
+            tokenNum++;
+            continue;
         }
 
         if(matchLen == *(token[tokenNum]))
         {
-            token_tree[token_pointer++] = *(token[tokenNum] + 1);
+            token_tree[tokenPointer++] = *(token[tokenNum] + 1);
 
             if(progLineLen == i)
             {
@@ -98,11 +103,9 @@ int lexer(unsigned char *program)
 
             matchLen = 0;
             progLineIndex = i;
-            tokenNum = -1;
+            tokenNum = 0;
         }
-
     }
-    while(token[tokenNum++]);
 
     return TRUE;
 }

--- a/lexer.h
+++ b/lexer.h
@@ -11,7 +11,7 @@
 #ifndef LEXER_H
 #define LEXER_H
 
-#define MAX_NUM_TOKENS 19
+#define MAX_NUM_TOKENS 20
 #define MAX_TOKEN_LEN 8
 #define MAX_TOKEN_TREE_SIZE 32
 #define TOKEN_HEADER_LEN 2

--- a/tasks.h
+++ b/tasks.h
@@ -17,15 +17,15 @@
 #define ENABLE 1
 #define DISABLE 0
 
-void taskManager(void);
+char* binToAscii(char* line, short val);
 
-static void taskSleep(int);
+void taskManager(void);
+void taskSleep(int);
+void taskControl(int task, short control);
+
 static void taskTimeoutLock(short task, short count);
 static void taskSuspend(int task);
 static void taskContinue(int task);
-static void taskControl(int task, short control);
-
-char* binToAscii(char* line, short val);
 
 static short task_1(void);
 static short task_2(void);


### PR DESCRIPTION
serveral changes, including moving the code which was running interpreter functions in tasks.c/task_4() over to interpreter.c, fixed another lexer bug, temporary code additional to test using taskSleep() over in interpreter.c, out="Hello world" and pause=taskSleep(1).

Following example prints out "Hello world" every second.
out
pause
rerun
