### PR TITLE
added-led-on-off-fixed-multi-uart-in-ast-block

### DIFF
--- a/interpreter.c
+++ b/interpreter.c
@@ -126,6 +126,21 @@ int interpreter(int *tokenTreeIndex, unsigned char *tokenTree) // abstract synta
         _finish(tokenTreeIndex);
         break;
 
+        case 'M': // 0x4D led
+        debug(uartTxBuf, 0, "M\r\n");
+        runState = _led(tokenTreeIndex, tokenTree);
+        break;
+
+        case 'I': // 0x49 on
+        debug(uartTxBuf, 0, "I\r\n");
+        runState = _on(tokenTreeIndex, tokenTree);
+        break;
+
+        case 'J': // 0x4A off
+        debug(uartTxBuf, 0, "J\r\n");
+        runState = _off(tokenTreeIndex, tokenTree);
+        break;
+
         case 0x01: // ctrl-c
         uartTx(uartTxBuf, 0, "program terminated\r\n");
         _finish(tokenTreeIndex);
@@ -144,16 +159,6 @@ int interpreter(int *tokenTreeIndex, unsigned char *tokenTree) // abstract synta
 
         case 'L': // no:
         debug(uartTxBuf, 0, "L\r\n");
-        runState = tokenTree[tokenTreeIndex++];
-        break;
-
-        case 'M': // led1
-        debug(uartTxBuf, 0, "M\r\n");
-        runState = tokenTree[tokenTreeIndex++];
-        break;
-
-        case 'N': // led2
-        debug(uartTxBuf, 0, "N\r\n");
         runState = tokenTree[tokenTreeIndex++];
         break;
 
@@ -224,6 +229,65 @@ int _string(int *tokenTreeIndex, unsigned char *tokenTree)
     return i; // runState
 }
 
+/*****************************************************************************/
+int _led(int *tokenTreeIndex, unsigned char *tokenTree)
+{
+    int runState;
+    unsigned char token;
+
+    token = tokenTree[++(*tokenTreeIndex)];
+
+    if(token == 'I' || token == 'J') // is next token on or off
+    {
+        runState = tokenTree[(*tokenTreeIndex)]; // set runState to on or off
+    }
+    else
+    {
+        runState = 0xFF;
+    }
+
+    return runState;
+}
+
+/*****************************************************************************/
+int _on(int *tokenTreeIndex, unsigned char *tokenTree)
+{
+    int i;
+
+    if(tokenTree[(*tokenTreeIndex - 1)] == 'M') // is previous token led
+    {
+        debug(uartTxBuf, 0, "led on\r\n");
+        P4OUT |= BIT0; // turn on user LED2
+        i = tokenTree[++(*tokenTreeIndex)];
+    }
+    else
+    {
+        ++(*tokenTreeIndex);
+        i = 0xFF;
+    }
+
+    return i; // runState
+}
+
+/*****************************************************************************/
+int _off(int *tokenTreeIndex, unsigned char *tokenTree)
+{
+    int i;
+
+    if(tokenTree[(*tokenTreeIndex - 1)] == 'M') // is previous token led
+    {
+        debug(uartTxBuf, 0, "led off\r\n");
+        P4OUT &= ~BIT0; // turn off user LED2
+        i = tokenTree[++(*tokenTreeIndex)];
+    }
+    else
+    {
+        ++(*tokenTreeIndex);
+        i = 0xFF;
+    }
+
+    return i; // runState
+}
 
 /*****************************************************************************/
 int _repeat(int *tokenTreeIndex, unsigned char *tokenTree)

--- a/interpreter.h
+++ b/interpreter.h
@@ -19,5 +19,8 @@ int _value(int *val, int *tokenTreeIndex, unsigned char *tokenTree);
 int _finish(int *tokenTreeIndex);
 int _rerun(int *tokenTreeIndex);
 int _end(int *tokenTreeIndex, unsigned char *tokenTree);
+int _led(int *tokenTreeIndex, unsigned char *tokenTree);
+int _on(int *tokenTreeIndex, unsigned char *tokenTree);
+int _off(int *tokenTreeIndex, unsigned char *tokenTree);
 
 #endif

--- a/lexer.c
+++ b/lexer.c
@@ -43,8 +43,7 @@ static unsigned char *token[MAX_NUM_TOKENS] = {TOKEN_IS,
                                                TOKEN_OFF,
                                                TOKEN_YES,
                                                TOKEN_NO,
-                                               TOKEN_LED1,
-                                               TOKEN_LED2,
+                                               TOKEN_LED,
                                                TOKEN_BUT1,
                                                TOKEN_BUT2,
                                                TOKEN_PRESSED,
@@ -188,12 +187,42 @@ int ast(unsigned char *tokenTree)
             if(tokenTree[blockPos] == 'D') // pause
             {
                 tokenTreeAst[tokenTreeIndex+i+k] = tokenTree[blockPos];
+                i++;
                 continue;
             }
 
             if(tokenTree[blockPos] == 'R') // finish
             {
                 tokenTreeAst[tokenTreeIndex+i+k] = tokenTree[blockPos];
+                i++;
+                continue;
+            }
+
+            if(tokenTree[blockPos] == 'M') // led
+            {
+                tokenTreeAst[tokenTreeIndex+i+k] = tokenTree[blockPos];
+                i++;
+                continue;
+            }
+
+            if(tokenTree[blockPos] == 'I') // on
+            {
+                tokenTreeAst[tokenTreeIndex+i+k] = tokenTree[blockPos];
+                i++;
+                continue;
+            }
+
+            if(tokenTree[blockPos] == 'J') // off
+            {
+                tokenTreeAst[tokenTreeIndex+i+k] = tokenTree[blockPos];
+                i++;
+                continue;
+            }
+
+            if(tokenTree[blockPos] == 'S') // rerun
+            {
+                tokenTreeAst[tokenTreeIndex+i+k] = tokenTree[blockPos];
+                i++;
                 continue;
             }
 
@@ -201,8 +230,10 @@ int ast(unsigned char *tokenTree)
             {
                 for(k=0;k<3;k++)
                 {
-                    tokenTreeAst[tokenTreeIndex+blockPos+i+k] = tokenTree[blockPos+k];
+                    tokenTreeAst[tokenTreeIndex+i+k] = tokenTree[blockPos+k];
                 }
+                k = 0;
+                i += 3;
             }
         }
 

--- a/lexer.h
+++ b/lexer.h
@@ -24,6 +24,10 @@
 #define MAX_STRING_LEN 32
 #define MAX_INT_LEN 8
 
+// Can't use LED1 GPIO 1.0, its assigned TXD for console uart.
+// Renaming LED1 to LED and assigning it GPIO 4.0, user LED2.
+// Token 'N' (0x4E) is available for use as a token.
+
 #define TOKEN_IS      "\x02" "\x41" "is"      // A
 #define TOKEN_REPEAT  "\x06" "\x42" "repeat"  // B
 #define TOKEN_SET     "\x03" "\x43" "set"     // C
@@ -36,8 +40,7 @@
 #define TOKEN_OFF     "\x03" "\x4A" "off"     // J
 #define TOKEN_YES     "\x04" "\x4B" "yes:"    // K
 #define TOKEN_NO      "\x03" "\x4C" "no:"     // L
-#define TOKEN_LED1    "\x04" "\x4D" "led1"    // M
-#define TOKEN_LED2    "\x04" "\x4E" "led2"    // N
+#define TOKEN_LED     "\x03" "\x4D" "led"     // M
 #define TOKEN_BUT1    "\x04" "\x4F" "but1"    // O
 #define TOKEN_BUT2    "\x04" "\x50" "but2"    // P
 #define TOKEN_PRESSED "\x07" "\x51" "pressed" // Q

--- a/tasks.c
+++ b/tasks.c
@@ -85,8 +85,7 @@ static unsigned char key_words[] = CRLF
                                   "off" CRLF
                                   "yes:" CRLF
                                   "no:" CRLF
-                                  "led1" CRLF
-                                  "led2" CRLF
+                                  "led" CRLF
                                   "but1" CRLF
                                   "but2" CRLF
                                   "pressed" CRLF

--- a/twine.h
+++ b/twine.h
@@ -6,7 +6,7 @@
  *
  * Twine is a strong thread or string consisting of two or more strands.
  *
- * Copyright (C) 2022 Alex Pogostin <alex.pogostin@outlook.com>
+ * Copyright (C) 2024 Alex Pogostin <alex.pogostin@outlook.com>
  *
  */
 


### PR DESCRIPTION
There is an issue using LED1 (GPIO 1.0), its sharing the TXD of the console uart, so removed that. Using user LED2 (GPIO 4.0) as the LED. Now can turn on and off LED. Also fixed the issue with multiple uart statements in the AST block. Enabled the use of the rerun token.,