### PR TITLE
adding-lcd-display-feature

### DIFF
--- a/interpreter.c
+++ b/interpreter.c
@@ -76,7 +76,12 @@ int interpreter(int *tokenTreeIndex, unsigned char *tokenTree) // abstract synta
     {
         case 'H': // 0x48 uart
         debug(uartTxBuf, 0, "H\r\n");
-        runState = _uart(tokenTreeIndex, tokenTree);
+        runState = _uart_lcd(tokenTreeIndex, tokenTree);
+        break;
+
+        case 'U': // 0x55 lcd
+        debug(uartTxBuf, 0, "U\r\n");
+        runState = _uart_lcd(tokenTreeIndex, tokenTree);
         break;
 
         case 'X': // 0x58 string
@@ -190,9 +195,7 @@ int interpreter(int *tokenTreeIndex, unsigned char *tokenTree) // abstract synta
 }
 
 /*****************************************************************************/
-//
-/*****************************************************************************/
-int _uart(int *tokenTreeIndex, unsigned char *tokenTree)
+int _uart_lcd(int *tokenTreeIndex, unsigned char *tokenTree)
 {
     int runState;
 
@@ -212,12 +215,33 @@ int _uart(int *tokenTreeIndex, unsigned char *tokenTree)
 int _string(int *tokenTreeIndex, unsigned char *tokenTree)
 {
     int i;
+    int j;
+    int k;
 
-    if(tokenTree[(*tokenTreeIndex - 1)] == 'H') // is previous token uart
+    if(tokenTree[(*tokenTreeIndex - 1)] == 'H')// is previous token uart
     {
         i = tokenTree[++(*tokenTreeIndex)];
         uartTx(uartTxBuf, 0, &strVars[i & 0x0F][0]);
         uartTx(uartTxBuf, 0, CRLF);
+        i = tokenTree[++(*tokenTreeIndex)];
+    }
+    else if (tokenTree[(*tokenTreeIndex - 1)] == 'U') // is previous token lcd
+    {
+        i = tokenTree[++(*tokenTreeIndex)];
+
+        writeLcd(0,0); // clear all 5 digits
+
+        for(k=0;k<32;k++) // look for end of strVar[][]
+        {
+            if(strVars[i & 0x0F][k] == 0)
+                break;
+        }
+
+        for(j=0;j<k;j++)
+        {
+            writeLcd(strVars[i & 0x0F][j], j + 1);
+        }
+
         i = tokenTree[++(*tokenTreeIndex)];
     }
     else

--- a/lcd.c
+++ b/lcd.c
@@ -1,0 +1,105 @@
+
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * lcd.c
+ *
+ * LCD routines.
+ *
+ * Copyright (C) 2024 Alex Pogostin <alex.pogostin@outlook.com>
+ *
+ */
+
+/*
+ * The initLcd(...) parameters below were found in the MSP-EXP430FR4133 LaundPad example code.
+ * https://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSP-EXP430FR4133/latest/index_FDS.html
+ * MSP-EXP430FR4133_Software_Examples_windows.zip
+ */
+
+#include "twine.h"
+
+static unsigned char *ascii_table[MAX_NUM_TOKENS] = {ASCII_0x30,
+                                                     ASCII_0x31,
+                                                     ASCII_0x32,
+                                                     ASCII_0x33,
+                                                     ASCII_0x34,
+                                                     ASCII_0x35,
+                                                     ASCII_0x36,
+                                                     ASCII_0x37,
+                                                     ASCII_0x38,
+                                                     ASCII_0x39,
+                                                    };
+
+void initLcd(void)
+{
+    LCDPCTL0 = 0xFFFF; // L0-L15 set as segment pins
+    LCDPCTL1 = 0x07FF; // L16-L26 set as segment pins
+    LCDPCTL2 = 0x00F0; // L36-L39 set as segment pins
+    LCDCTL0 = 0x181C; // init clocks (4-mux mode), leave LCDON=0 (off)
+    LCDVCTL = 0xF0C0; // voltage control register
+    LCDCSSEL0 = 0x000F; // L0=COM0, L1=COM1, L2=COM2, L3=COM3
+    LCDCTL0 |= LCDON;   // turn on LCD
+    SYSCFG2 |= LCDPCTL; // turn on LCD power pin
+}
+
+short writeLcd(unsigned char ascii, unsigned char location)
+{
+
+    if(location)
+    {
+        ascii -= 48; // temporary until we fill in the entire ascii_table[].
+        LCDM1 = *(ascii_table[ascii] + 0);
+        LCDM0 = *(ascii_table[ascii] + 1);
+    }
+    else
+    {
+        LCDM1 = 0;
+        LCDM0 = 0;;
+    }
+
+    switch (location)
+    {
+        case 0:
+        LCDM5 = 0;
+        LCDM4 = 0;
+        LCDM7 = 0;
+        LCDM6 = 0;
+        LCDM9 = 0;
+        LCDM8 = 0;
+        LCDM11 = 0;
+        LCDM10 = 0;
+        LCDM3 = 0;
+        LCDM2 = 0;
+        break;
+
+        case 1:
+        LCDM5 = *(ascii_table[ascii] + 2);
+        LCDM4 = *(ascii_table[ascii] + 3);
+        break;
+
+        case 2:
+        LCDM7 = *(ascii_table[ascii] + 2);
+        LCDM6 = *(ascii_table[ascii] + 3);
+        break;
+
+        case 3:
+        LCDM9 = *(ascii_table[ascii] + 2);
+        LCDM8 = *(ascii_table[ascii] + 3);
+        break;
+
+        case 4:
+        LCDM11 = *(ascii_table[ascii] + 2);
+        LCDM10 = *(ascii_table[ascii] + 3);
+        break;
+
+        case 5:
+        LCDM3 = *(ascii_table[ascii] + 2);
+        LCDM2 = *(ascii_table[ascii] + 3);
+        break;
+
+        default:
+        break;
+    };
+
+    return TRUE;
+}
+

--- a/lcd.h
+++ b/lcd.h
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+/*
+ * lcd.h
+ *
+ * Copyright (C) 2024 Alex Pogostin <alex.pogostin@outlook.com>
+ *
+ */
+
+#ifndef LCD_H
+#define LCD_H
+
+// 0 = ABCDEFKQ
+// 1 = KBC
+// 2 = ABGMED
+// 3 = ABMCD
+// 4 = FGMBC
+// 5 = AFGMDC
+// 6 = AFGMCDE
+// 7 = ABC
+// 8 = ABCDEFGM
+// 9 = ABGMFCD
+
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84 = COM3 COM2
+// LCDM0   0   0   1   0   0   0   0   1 = 0x21 = COM1 COM0
+
+// LCDM5 A1H A1J A1K A1P A1Q NEG A1N A1DP
+//         0   0   0   0   0   0   0   0
+// LCDM4 A1A A1B A1C A1D A1E A1F A1G A1M
+//         0   0   0   0   0   0   0   0
+
+// '0'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   1 = 0x20
+// LCDM5   0   0   1   0   1   0   0   0 = 0x28
+// LCDM4   1   1   1   1   1   1   0   0 = 0xFC
+
+// '1'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   0 = 0x20
+// LCDM5   0   0   1   0   0   0   0   0 = 0x20
+// LCDM4   0   1   1   0   0   0   0   0 = 0x60
+
+// '2'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   1 = 0x21
+// LCDM5   0   0   0   0   0   0   0   0 = 0x00
+// LCDM4   1   1   0   1   1   0   1   1 = 0xDB
+
+// '3'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   1 = 0x21
+// LCDM5   0   0   0   0   0   0   0   0 = 0x00
+// LCDM4   1   1   1   1   0   0   0   1 = 0xF1
+
+// '4'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x04
+// LCDM0   0   0   1   0   0   0   0   1 = 0x21
+// LCDM5   0   0   0   0   0   0   0   0 = 0x00
+// LCDM4   0   1   1   0   0   1   1   1 = 0x67
+
+// '5'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   1 = 0x21
+// LCDM5   0   0   0   0   0   0   0   0 = 0x00
+// LCDM4   1   0   1   1   0   1   1   1 = 0xB7
+
+// '6'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   1 = 0x21
+// LCDM5   0   0   0   0   0   0   0   0 = 0x00
+// LCDM4   1   0   1   1   1   1   1   1 = 0xBF
+
+// '7'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   0 = 0x20
+// LCDM5   0   0   0   0   0   0   0   0 = 0x00
+// LCDM4   1   1   1   0   0   0   0   0 = 0xE0
+
+// '8'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   0 = 0x20
+// LCDM5   0   0   0   0   0   0   0   0 = 0x00
+// LCDM4   1   1   1   1   1   1   1   1 = 0xFF
+
+// '9'
+// LCDM1   1   0   0   0   0   1   0   0 = 0x84
+// LCDM0   0   0   1   0   0   0   0   1 = 0x21
+// LCDM5   0   0   0   0   0   0   0   0 = 0x00
+// LCDM4   1   1   1   1   0   1   1   1 = 0xF7
+
+// 1, 7 and 8 have COM0 cleared, but that messes
+// up the display when outputting these numbers
+// in a certain pattern?? setting them with COM0=1
+// as other ASCII charaters are output, there
+// may be some patter - or understanding
+// as to why this is occuring.
+
+#define ASCII_0x30 "\x84" "\x21" "\x28" "\xFC" // 0
+#define ASCII_0x31 "\x84" "\x21" "\x20" "\x60" // 1
+#define ASCII_0x32 "\x84" "\x21" "\x00" "\xDB" // 2
+#define ASCII_0x33 "\x84" "\x21" "\x00" "\xF1" // 3
+#define ASCII_0x34 "\x04" "\x21" "\x00" "\x67" // 4
+#define ASCII_0x35 "\x84" "\x21" "\x00" "\xB7" // 5
+#define ASCII_0x36 "\x84" "\x21" "\x00" "\xBF" // 6
+#define ASCII_0x37 "\x84" "\x21" "\x00" "\xE0" // 7
+#define ASCII_0x38 "\x84" "\x21" "\x00" "\xFF" // 8
+#define ASCII_0x39 "\x84" "\x21" "\x00" "\xF7" // 9
+
+void initLcd(void);
+short writeLcd(unsigned char ascii, unsigned char location);
+
+#endif

--- a/lexer.c
+++ b/lexer.c
@@ -235,6 +235,16 @@ int ast(unsigned char *tokenTree)
                 k = 0;
                 i += 3;
             }
+
+            if(tokenTree[blockPos] == 'U') // lcd
+            {
+                for(k=0;k<3;k++)
+                {
+                    tokenTreeAst[tokenTreeIndex+i+k] = tokenTree[blockPos+k];
+                }
+                k = 0;
+                i += 3;
+            }
         }
 
         tokenTreeAst[statementEnd] = 'T';

--- a/main.c
+++ b/main.c
@@ -30,6 +30,9 @@ int main(void)
     startXt1Clk();
     startRtcClk();
     uartInit();
+    initLcd();
+
+    writeLcd(0,0); // clear LCD
 
     // If this is a power up then wait for USB enumeration.
     // Allows use with "backchannel" UART-over-USB at power-up.

--- a/twine.h
+++ b/twine.h
@@ -23,9 +23,12 @@
 #include "string.h"
 #include "lexer.h"
 #include "interpreter.h"
+#include "lcd.h"
 
 #define read_reg_8(x) (*((volatile unsigned char *)((unsigned short)x)))
 #define read_reg_16(x) (*((volatile unsigned short *)((unsigned short)x)))
+
+#define write_reg_16(x) (*((volatile unsigned short *)((unsigned short)x)))
 
 #define MAX_PROG_LINES 32
 #define MAX_PROG_LINE_LEN 32


### PR DESCRIPTION
This is the first iteration of for displaying characters on the LCD display. Several areas can be improved once the ASCII table is complete. At this point, just wanted to test the basics, so added only numbers 0 through 9. So only those are located in the ascii_table[][] used by the writeLcd(...) code. I'm thinking that there are some workarounds that I made just to get by - for now.