### PR TITLE
fixing bug #21 - console prompt missing if no "T" in file

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -171,6 +171,11 @@ int ast(unsigned char *tokenTree)
             }
         }
 
+        if(statementEnd == MAX_TOKEN_TREE_SIZE)
+        {
+            break;
+        }
+
         for(conditionalPos=tokenTreeIndex;conditionalPos<statementEnd;conditionalPos++)
         {
             if(tokenTree[conditionalPos] == 'B') // repeat

--- a/tasks.c
+++ b/tasks.c
@@ -16,7 +16,7 @@
 extern unsigned char uartRxBuf[UART_RX_BUF_SIZE];
 extern unsigned char uartTxBuf[UART_TX_BUF_ARRAY_SIZE][UART_TX_BUF_SIZE];
 extern unsigned char tokenTree[MAX_TOKEN_TREE_SIZE];
-extern unsigned char tokenTreeAst[16];
+extern unsigned char tokenTreeAst[MAX_TOKEN_TREE_SIZE];
 extern int tokenTreeIndex;
 extern unsigned char strVars[4][32];
 extern int strVarsIndex;


### PR DESCRIPTION
This fixes the console prompt missing if no "T found in file, bug #21. Merging into master.