### PR TITLE
Fix interrupts c

### DIFF
--- a/interrupts.c
+++ b/interrupts.c
@@ -13,7 +13,7 @@
 /*****************************************************************************/
 /* global declarations                                                       */
 /*****************************************************************************/
-#define RXBUF_REGISTER 0x0C
+#define OFS_UCA0RXBUF 0x0C
 /*****************************************************************************/
 /* externs - these global variables are declared in tasks.c                  */
 /*****************************************************************************/
@@ -90,7 +90,7 @@ __interrupt void USCIA0Interrupt(void)
         break;
 
         case 0x02: // RX interrupt
-            rxReg = read_reg_8(EUSCI_A0_BASE + RXBUF_REGISTER);
+            rxReg = read_reg_8(EUSCI_A0_BASE + OFS_UCA0RXBUF);
             if(i < UART_RX_BUF_SIZE - 1)
             {
                 if(rxReg == BACKSPACE)

--- a/interrupts.c
+++ b/interrupts.c
@@ -11,6 +11,10 @@
 #include "twine.h"
 
 /*****************************************************************************/
+/* global declarations                                                       */
+/*****************************************************************************/
+#define RXBUF_REGISTER 0x0C
+/*****************************************************************************/
 /* externs - these global variables are declared in tasks.c                  */
 /*****************************************************************************/
 extern unsigned short task_1_status;
@@ -86,7 +90,7 @@ __interrupt void USCIA0Interrupt(void)
         break;
 
         case 0x02: // RX interrupt
-            rxReg = read_reg_8(EUSCI_A0_BASE + UCA0RXBUF);
+            rxReg = read_reg_8(EUSCI_A0_BASE + RXBUF_REGISTER);
             if(i < UART_RX_BUF_SIZE - 1)
             {
                 if(rxReg == BACKSPACE)


### PR DESCRIPTION
The UCA0RXBUF macro which is defined in the msp430fr4133.h is not a direct offset from the UART base register. Needed to create OFS_UCA0RXBUF macro which equals the offset of 0x0C. Searching the msp430\include folders for all the other MSP430 processor includes, do see OFS_UCA0RXBUF in other MSP430 types which are equal to 0x0C - not sure why its missing from the FR4133 include??